### PR TITLE
First Iteration of class size predictor

### DIFF
--- a/test/data/one_class.json
+++ b/test/data/one_class.json
@@ -1,0 +1,106 @@
+{
+  "course": "csc115",
+  "prereq": [
+    "csc110",
+    "csc111"
+  ],
+  "coreq": [
+  ],
+  "pastEnrol": [
+    {
+        "year": 2017,
+        "term": 2,
+        "size": 75
+    },
+    {
+        "year": 2017,
+        "term": 3,
+        "size": 132
+    },
+    {
+        "year": 2018,
+        "term": 1,
+        "size": 352
+    },
+    {
+        "year": 2018,
+        "term": 2,
+        "size": 105
+    },
+    {
+        "year": 2018,
+        "term": 3,
+        "size": 129
+    },
+    {
+        "year": 2019,
+        "term": 1,
+        "size": 357
+    },
+    {
+        "year": 2019,
+        "term": 2,
+        "size": 86
+    },
+    {
+        "year": 2019,
+        "term": 3,
+        "size": 130
+    },
+    {
+        "year": 2020,
+        "term": 1,
+        "size": 299
+    },
+    {
+        "year": 2020,
+        "term": 2,
+        "size": 132
+    },
+    {
+        "year": 2020,
+        "term": 3,
+        "size": 156
+    },
+    {
+        "year": 2021,
+        "term": 1,
+        "size": 312
+    },
+    {
+        "year": 2021,
+        "term": 2,
+        "size": 146
+    },
+    {
+        "year": 2021,
+        "term": 3,
+        "size": 135
+    },
+    {
+        "year": 2022,
+        "term": 1,
+        "size": 316
+    },
+    {
+        "year": 2022,
+        "term": 2,
+        "size": 91
+    },
+    {
+        "year": 2022,
+        "term": 3,
+        "size": 159
+    },
+    {
+        "year": 2023,
+        "term": 1,
+        "size": 353
+    },
+    {
+        "year": 2023,
+        "term": 2,
+        "size": 85
+    }
+  ]
+}

--- a/test/data/one_class.json
+++ b/test/data/one_class.json
@@ -9,12 +9,12 @@
   "pastEnrol": [
     {
         "year": 2017,
-        "term": 2,
+        "term": 5,
         "size": 75
     },
     {
         "year": 2017,
-        "term": 3,
+        "term": 9,
         "size": 132
     },
     {
@@ -24,12 +24,12 @@
     },
     {
         "year": 2018,
-        "term": 2,
+        "term": 5,
         "size": 105
     },
     {
         "year": 2018,
-        "term": 3,
+        "term": 9,
         "size": 129
     },
     {
@@ -39,12 +39,12 @@
     },
     {
         "year": 2019,
-        "term": 2,
+        "term": 5,
         "size": 86
     },
     {
         "year": 2019,
-        "term": 3,
+        "term": 9,
         "size": 130
     },
     {
@@ -54,12 +54,12 @@
     },
     {
         "year": 2020,
-        "term": 2,
+        "term": 5,
         "size": 132
     },
     {
         "year": 2020,
-        "term": 3,
+        "term": 9,
         "size": 156
     },
     {
@@ -69,12 +69,12 @@
     },
     {
         "year": 2021,
-        "term": 2,
+        "term": 5,
         "size": 146
     },
     {
         "year": 2021,
-        "term": 3,
+        "term": 9,
         "size": 135
     },
     {
@@ -84,12 +84,12 @@
     },
     {
         "year": 2022,
-        "term": 2,
+        "term": 5,
         "size": 91
     },
     {
         "year": 2022,
-        "term": 3,
+        "term": 9,
         "size": 159
     },
     {
@@ -99,7 +99,7 @@
     },
     {
         "year": 2023,
-        "term": 2,
+        "term": 5,
         "size": 85
     }
   ]


### PR DESCRIPTION
Class size predictor takes in data in the 
`"course": "csc115",
  "prereq": [
    "csc110",
    "csc111"
  ],
  "coreq": [
  ],
  "pastEnrol": [
    {
        "year": 2017,
        "term": 5,
        "size": 75
    },
    {
        "year": 2017,
        "term": 9,
        "size": 132
    },...
    
}]`

and prints predictions in JSON format:
`[{'terms': ['2023-09', '2024-01', '2024-05'], 'sizes': [120, 284, 89], 'course': 'csc115'}]`